### PR TITLE
Cancel any scrolling debounce when the component is destroyed

### DIFF
--- a/addon/components/infinite-scroller.js
+++ b/addon/components/infinite-scroller.js
@@ -1,7 +1,7 @@
 import Component from 'ember-component';
 import layout from '../templates/components/infinite-scroller';
 import { guidFor } from 'ember-metal/utils';
-import { bind, debounce } from 'ember-runloop';
+import { bind, debounce, cancel } from 'ember-runloop';
 import RSVP from 'rsvp';
 import inject from 'ember-service/inject';
 const { round } = Math;
@@ -22,13 +22,15 @@ export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
     this.$scroller().on(this.get('scrollEventName'), args => {
-      debounce(this, '_scrollingElement', args, this._scrollDebounce());
+      this.set('_scrollDebounceCancelId',
+        debounce(this, '_scrollingElement', args, this._scrollDebounce()));
     });
   },
 
   willDestroyElement() {
     this._super(...arguments);
     this.$scroller().off(this.get('scrollEventName'));
+    cancel(this.get('_scrollDebounceCancelId'));
   },
 
   _scrollDebounce() {

--- a/tests/integration/components/infinite-scroller-test.js
+++ b/tests/integration/components/infinite-scroller-test.js
@@ -341,3 +341,35 @@ test('no promise (does not blow up)', function(assert) {
 
   return wait();
 });
+
+test('destroying during debounce (does not blow up)', function(assert) {
+  assert.expect(0);
+
+  this.set('show', true);
+  this.set('things', generateThings(1, 20));
+
+  this.on('loadMore', () => {
+    return null;
+  });
+
+  this.render(hbs`
+    {{#if show}}
+      {{#infinite-scroller
+        class="example-1"
+        scroll-debounce=50
+        on-load-more=(action 'loadMore') as |scroller|}}
+        {{#each things as |thing|}}
+          <div class="thing">{{thing.name}}</div>
+        {{/each}}
+      {{/infinite-scroller}}
+    {{/if}}
+  `);
+
+  this.$('.infinite-scroller').scrollTop(450);
+
+  later(() => {
+    this.set('show', false);
+  }, 25);
+
+  return wait();
+});


### PR DESCRIPTION
If the component is destroyed before a debounce `_scrollingElement` is run, the following error will result from the element no longer existing:

```js
TypeError: Cannot read property 'scrollTop' of undefined
    at Class._scrollTop (infinite-scroller.js:63)
    at Class._scrollPercentage (infinite-scroller.js:70)
    at Class._reachedBottom (infinite-scroller.js:76)
    at Class._shouldLoadMore (infinite-scroller.js:79)
    at Class._scrollingElement (infinite-scroller.js:82)
    at Backburner.run (ember.debug.js:2558)
    at ember.debug.js:2869
```

This PR keeps track of the `cancelId` for the scrolling debounce, canceling it if the component is destroyed.